### PR TITLE
Fix retry policy in forecast workflow

### DIFF
--- a/workflows.py
+++ b/workflows.py
@@ -62,7 +62,8 @@ class GetForecastWorkflow:
             "make_nws_request",
             forecast_url,
             schedule_to_close_timeout=timedelta(seconds=40),
-            retry_policy=dict(),
+            # Use the same retry policy as other network calls
+            retry_policy=retry_policy,
         )
         if not forecast_data:
             return "Unable to fetch detailed forecast."


### PR DESCRIPTION
## Summary
- use consistent retry policy for `GetForecastWorkflow`

## Testing
- `python -m py_compile main.py activities.py weather.py worker.py workflows.py`
